### PR TITLE
refactor: only allow conventionalcommits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,16 +2,9 @@ name: "Semantic PR"
 description: "Helps ensure that pull requests will be merged and creates the desired outcome of semantic-release. "
 author: "levibostian"
 inputs: 
-  rules:
-    description: "commitlint rules set to follow. Name for file path or npm module name of installed module. Default: @commitlint/config-conventional"
-    default: "@commitlint/config-conventional"
-    required: true
   token:
     description: "GitHub personal access token for user who has the ability to comment on pull requests."
     required: true
-  invalidPrTitleMessagePath:
-    description: "Relative path to file containing message to send on pull request when pull request title is invalid."
-    required: false 
 runs:
   using: "node16"
   main: "dist/index.js"

--- a/app/assets/invalid_pr_title_help.md
+++ b/app/assets/invalid_pr_title_help.md
@@ -8,6 +8,12 @@ This pull request title should be in this format:
 <type>: short description of change being made
 ```
 
+**If your pull request introduces breaking changes** to the code, use this format:
+
+```
+<type>!: short description of breaking change
+```
+
 where `<type>` is one of the following:
 
 - `feat:` - A new feature is being added by this pull request.
@@ -24,14 +30,12 @@ where `<type>` is one of the following:
 - `chore:` - Other changes to project that don't modify source code or test files.
 - `revert:` - Reverts a previous commit that was made.
 
-**If your pull request causes breaking changes** to the code base, you need to add a `!` after the `<type>`: `feat!: remove deprecated v1 endpoints`
-
 <details>
 <summary>Examples</summary>
 <br>
 ```
 feat: edit profile photo
-feat!: remove deprecated v1 endpoints
+refactor!: remove deprecated v1 endpoints
 build: update npm dependencies
 style: run formatter 
 ```
@@ -39,4 +43,4 @@ style: run formatter
 
 Need more examples? Want to learn more about this format? [Check out the official docs](https://www.conventionalcommits.org/).
 
-**Note:** If your pull request does multiple things such as adding a feature _and_ makes changes to the CI server _and_ fixes some bugs then you might want to consider splitting this pull request up into multiple smaller pull requests. Small and focused pull requests are preferred by the reviewers of the code.
+**Note:** If your pull request does multiple things such as adding a feature _and_ makes changes to the CI server _and_ fixes some bugs then you might want to consider splitting this pull request up into multiple smaller pull requests.

--- a/app/index.ts
+++ b/app/index.ts
@@ -37,32 +37,26 @@ import { getInvalidPrTitleHelp, getValidPrTitleMessage } from "./helper_messages
   const prTitle = pullRequest.data.title
   const prAuthor = pullRequest.data.user?.login || ""
 
-  const isTitleValid = await lintPrTitle(prTitle, input.rules)
+  const isTitleValid = await lintPrTitle(prTitle, "@commitlint/config-conventional")
   if (!isTitleValid) {
-    await cathy.speak(
-      getInvalidPrTitleHelp(prAuthor, { filePath: input.invalidPrTitleMessagePath }),
-      {
-        githubToken: input.token,
-        githubRepo: `${githubContext.repo.owner}/${githubContext.repo.repo}`,
-        githubIssue: prNumber,
-        updateExisting: true,
-        updateID: "action-semantic-pr_help-pr-title"
-      }
-    )
-
-    return terminate(new Error("Pull request title is not valid."))
-  }
-
-  await cathy.speak(
-    getValidPrTitleMessage(prAuthor, { filePath: input.invalidPrTitleMessagePath }),
-    {
+    await cathy.speak(getInvalidPrTitleHelp(prAuthor), {
       githubToken: input.token,
       githubRepo: `${githubContext.repo.owner}/${githubContext.repo.repo}`,
       githubIssue: prNumber,
       updateExisting: true,
       updateID: "action-semantic-pr_help-pr-title"
-    }
-  )
+    })
+
+    return terminate(new Error("Pull request title is not valid."))
+  }
+
+  await cathy.speak(getValidPrTitleMessage(prAuthor), {
+    githubToken: input.token,
+    githubRepo: `${githubContext.repo.owner}/${githubContext.repo.repo}`,
+    githubIssue: prNumber,
+    updateExisting: true,
+    updateID: "action-semantic-pr_help-pr-title"
+  })
 
   log.info("Looks like the PR title is valid!")
 

--- a/app/input.ts
+++ b/app/input.ts
@@ -2,15 +2,11 @@ import { Input } from "./type/input"
 import * as core from "@actions/core"
 
 export const defaults: Input = {
-  rules: "@commitlint/config-conventional",
-  token: "",
-  invalidPrTitleMessagePath: undefined
+  token: ""
 }
 
 export const getInput = (): Input => {
   return {
-    rules: core.getInput("rules"),
-    token: core.getInput("token"),
-    invalidPrTitleMessagePath: core.getInput("invalidPrTitleMessagePath")
+    token: core.getInput("token")
   }
 }

--- a/app/lint.test.ts
+++ b/app/lint.test.ts
@@ -1,23 +1,19 @@
 import * as lint from "./lint"
-import { defaults } from "./input"
 
 describe("lintPrTitle", () => {
   it(`given empty string, expect false`, async () => {
-    expect(await lint.lintPrTitle("", defaults.rules)).toEqual(false)
-  })
-  it(`given empty rules set, expect false`, async () => {
-    expect(await lint.lintPrTitle("feat: foo", "")).toEqual(false)
+    expect(await lint.lintPrTitle("")).toEqual(false)
   })
   it(`given invalid rules set, expect false`, async () => {
     expect(await lint.lintPrTitle("feat: foo", "@commitlint/invalid-config")).toEqual(false)
   })
   it(`given invalid title, expect false`, async () => {
-    expect(await lint.lintPrTitle("foo: bar", defaults.rules)).toEqual(false)
+    expect(await lint.lintPrTitle("foo: bar")).toEqual(false)
   })
   it(`given valid title, expect true`, async () => {
-    expect(await lint.lintPrTitle("feat: bar", defaults.rules)).toEqual(true)
+    expect(await lint.lintPrTitle("feat: bar")).toEqual(true)
   })
   it(`given breaking change conventional title, expect true`, async () => {
-    expect(await lint.lintPrTitle("feat!: bar", defaults.rules)).toEqual(true)
+    expect(await lint.lintPrTitle("feat!: bar")).toEqual(true)
   })
 })

--- a/app/lint.ts
+++ b/app/lint.ts
@@ -3,8 +3,10 @@ import { LintOptions, ParserOptions, QualifiedConfig } from "@commitlint/types"
 import load from "@commitlint/load"
 import * as log from "./log"
 
-export const lintPrTitle = async (title: string, rulesName: string): Promise<boolean> => {
+export const lintPrTitle = async (title: string, rulesName?: string): Promise<boolean> => {
   title = title.trim()
+  rulesName = rulesName || "@commitlint/config-conventional"
+
   if (title == "") return false
 
   log.debug(`Linting PR ${title} with rules: ${rulesName}`)

--- a/app/type/input.ts
+++ b/app/type/input.ts
@@ -1,5 +1,3 @@
 export interface Input {
-  rules: string
   token: string
-  invalidPrTitleMessagePath?: string
 }


### PR DESCRIPTION
Only use conventionalcommits as it's going to be the easiest preset to build this action for. Also, it's the only format I use for my projects so it will work for my needs for now. 

Example: For introducing breaking changes into the squashed merge, using conventional commits it's easy. When you use `refactor!: remove onComplete callbacks`, `Remove onComplete callbacks` is the breaking change message. When the action squash merges a PR, it just needs to squash merge with the PR title and the next deploy will result in a major version bump. If this action needs to support Angular preset, the bot needs to be able to capture the breaking change from the PR author in a different way and then add that breaking change message into the footer of the squashed merge message. That's more work then just being able to use the PR title. 